### PR TITLE
Feature/fix theme style

### DIFF
--- a/src/templates/code-theme.scss
+++ b/src/templates/code-theme.scss
@@ -56,6 +56,7 @@
 
     /* Inline code */
     :not(pre) > code[class*='language-'] {
+      white-space: initial;
       padding: 5px 10px;
       line-height: 1;
       -moz-border-radius: 3px;
@@ -235,6 +236,7 @@
 
     /* Inline code */
     :not(pre) > code[class*='language-'] {
+      white-space: initial;
       padding: 0.2em;
       padding-top: 1px;
       padding-bottom: 1px;

--- a/src/templates/md-style.scss
+++ b/src/templates/md-style.scss
@@ -26,6 +26,7 @@
   }
   hr {
     margin: 1.5rem 0;
+    background-color: #cccccc;
   }
   code {
     font-family: 'Nanum Gothic Coding' !important;


### PR DESCRIPTION
modify two style's features

- fix `<hr/>` tag disappear in darkmood
The `<hr/>` with transparency in background-color we can't see in a dark mode.
I add `background-color: #cccccc;` under `md-style.scss`.
Because it seems like the original color. 😂

- fix "Inline code" style in the mobile version
The "Inline code" didn't auto wrap. It will break the style when the line too long, especially in a mobile version.